### PR TITLE
Use assertBytes from noble-hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,8 @@ const sig = hdkey3.sign(hash);
 hdkey3.verify(hash, sig);
 ```
 
-Note: do not set `privateKey` and `publicKey` directly, you will get wrong keys.
+Note: `chainCode` property is essentially a private part
+of a secret "master" key, it should be guarded from unauthorized access.
 
 The full API is:
 
@@ -232,26 +233,25 @@ class HDKey {
   public static fromExtendedKey(base58key: string, versions: Versions): HDKey;
   public static fromJSON(json: { xpriv: string }): HDKey;
 
-  public versions: Versions;
-  public depth: number;
-  public index: number;
-  public chainCode: Uint8Array | null;
-  public privateKey: Uint8Array | null;
-  public publicKey: Uint8Array | null;
-  public fingerprint: number;
-  public parentFingerprint: number;
-  public pubKeyHash: Uint8Array | undefined;
-  public identifier: Uint8Array | undefined;
-  public privateExtendedKey: string;
-  public publicExtendedKey: string;
+  readonly versions: Versions;
+  readonly depth: number = 0;
+  readonly index: number = 0;
+  readonly chainCode: Uint8Array | null = null;
+  readonly parentFingerprint: number = 0;
 
-  private constructor(versios: Versions);
-  public derive(path: string): HDKey;
-  public deriveChild(index: number): HDKey;
-  public sign(hash: Uint8Array): Uint8Array;
-  public verify(hash: Uint8Array, signature: Uint8Array): boolean;
-  public wipePrivateData(): this;
-  public toJSON(): { xpriv: string; xpub: string };
+  get fingerprint(): number;
+  get identifier(): Uint8Array | undefined;
+  get pubKeyHash(): Uint8Array | undefined;
+  get privateKey(): Uint8Array | null;
+  get publicKey(): Uint8Array | null;
+  get privateExtendedKey(): string;
+  get publicExtendedKey(): string;
+
+  derive(path: string): HDKey;
+  deriveChild(index: number): HDKey;
+  sign(hash: Uint8Array): Uint8Array;
+  verify(hash: Uint8Array, signature: Uint8Array): boolean;
+  wipePrivateData(): this;
 }
 
 interface Versions {

--- a/README.md
+++ b/README.md
@@ -221,8 +221,7 @@ const sig = hdkey3.sign(hash);
 hdkey3.verify(hash, sig);
 ```
 
-Note: do not set `privateKey` and `publicKey` directly. Use `wipePrivateData()` to
-clean-up the instance.
+Note: do not set `privateKey` and `publicKey` directly, you will get wrong keys.
 
 The full API is:
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,26 @@ Note: if you've been using ethereum-cryptography v0.1, it had different API. We'
 
 ## BIP32 HD Keygen
 
-This module exports a single class whose type is
+This module exports a single class `HDKey`, which should be used like this:
+
+```ts
+const { HDKey } = require("ethereum-cryptography/secp256k1");
+const hdkey1 = HDKey.fromMasterSeed(seed);
+const hdkey2 = HDKey.fromExtendedKey(base58key);
+const hdkey3 = HDKey.fromJSON({ xpriv: string });
+
+// props
+[hdkey1.depth, hdkey1.index, hdkey1.chainCode];
+console.log(hdkey2.privateKey, hdkey2.publicKey);
+console.log(hdkey3.derive("m/0/2147483647'/1"));
+const sig = hdkey3.sign(hash);
+hdkey3.verify(hash, sig);
+```
+
+Note: do not set `privateKey` and `publicKey` directly. Use `wipePrivateData()` to
+clean-up the instance.
+
+The full API is:
 
 ```ts
 class HDKey {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "micro-base": "^0.10.0",
-    "@noble/hashes": "^0.5.1",
+    "@noble/hashes": "^0.5.2",
     "@noble/secp256k1": "^1.3.3"
   },
   "browser": {

--- a/src/bip39/index.ts
+++ b/src/bip39/index.ts
@@ -1,10 +1,9 @@
 import { pbkdf2, pbkdf2Async } from "@noble/hashes/pbkdf2";
 import { sha256 } from "@noble/hashes/sha256";
 import { sha512 } from "@noble/hashes/sha512";
-import { assertNumber } from "@noble/hashes/utils";
+import { assertBytes, assertNumber } from "@noble/hashes/utils";
 import { utils as baseUtils } from "micro-base";
 import { getRandomBytesSync } from "../random";
-import { assertBytes } from "../utils";
 
 const isJapanese = (wordlist: string[]) =>
   wordlist[0] === "\u3042\u3044\u3053\u304f\u3057\u3093"; // Japanese wordlist

--- a/src/hdkey.ts
+++ b/src/hdkey.ts
@@ -30,6 +30,7 @@ function modN(a: bigint, b: bigint = secp.CURVE.n): bigint {
 const MASTER_SECRET = utf8ToBytes("Bitcoin seed");
 // Bitcoin hardcoded by default
 const BITCOIN_VERSIONS: Versions = { private: 0x0488ade4, public: 0x0488b21e };
+export const HARDENED_OFFSET: number = 0x80000000;
 
 export interface Versions {
   private: number;
@@ -44,54 +45,97 @@ const toU32 = (n: number) => {
   return buf;
 };
 
+type HDKeyOpt = {
+  versions: Versions;
+  depth?: number;
+  index?: number;
+  parentFingerprint?: number;
+  chainCode: Uint8Array;
+  publicKey?: Uint8Array;
+  privateKey?: Uint8Array | bigint;
+};
+
 export class HDKey {
-  public static HARDENED_OFFSET: number = 0x80000000;
-  public static fromMasterSeed(seed: Uint8Array, versions?: Versions): HDKey {
-    const I = hmac(sha512, MASTER_SECRET, seed);
-    const hdkey = new HDKey(versions);
-    hdkey.chainCode = I.slice(32);
-    hdkey.privateKey = I.slice(0, 32);
-    return hdkey;
-  }
-  public static fromExtendedKey(base58key: string, versions?: Versions): HDKey {
-    // => version(4) || depth(1) || fingerprint(4) || index(4) || chain(32) || key(33)
-    const hdkey = new HDKey(versions);
-    const keyBuffer: Uint8Array = base58c.decode(base58key);
-    const keyView = createView(keyBuffer);
-    const version = keyView.getUint32(0, false);
-    hdkey.depth = keyBuffer[4];
-    hdkey.parentFingerprint = keyView.getUint32(5, false);
-    hdkey.index = keyView.getUint32(9, false);
-    hdkey.chainCode = keyBuffer.slice(13, 45);
-    const key = keyBuffer.slice(45);
-    const isPriv = key[0] === 0;
-    if (version !== hdkey.versions[isPriv ? "private" : "public"]) {
-      throw new Error("Version mismatch");
-    }
-    if (isPriv) {
-      hdkey.privateKey = key.slice(1);
-    } else {
-      hdkey.publicKey = key;
-    }
-    return hdkey;
-  }
-
-  public static fromJSON(json: { xpriv: string }): HDKey {
-    return HDKey.fromExtendedKey(json.xpriv);
-  }
-
-  public versions: Versions;
-  public depth: number = 0;
-  public index: number = 0;
-  public chainCode: Uint8Array | null = null;
-  public parentFingerprint: number = 0;
+  readonly versions: Versions;
+  readonly depth: number = 0;
+  readonly index: number = 0;
+  readonly chainCode: Uint8Array | null = null;
+  readonly parentFingerprint: number = 0;
   private privKey?: bigint;
   private privKeyBytes?: Uint8Array;
   private pubKey?: Uint8Array;
   private pubHash: Uint8Array | undefined;
 
-  constructor(versions?: Versions) {
-    this.versions = versions || BITCOIN_VERSIONS;
+  static fromMasterSeed(
+    seed: Uint8Array,
+    versions: Versions = BITCOIN_VERSIONS
+  ): HDKey {
+    const I = hmac(sha512, MASTER_SECRET, seed);
+    return new HDKey({
+      versions,
+      chainCode: I.slice(32),
+      privateKey: I.slice(0, 32)
+    });
+  }
+
+  static fromExtendedKey(
+    base58key: string,
+    versions: Versions = BITCOIN_VERSIONS
+  ): HDKey {
+    // => version(4) || depth(1) || fingerprint(4) || index(4) || chain(32) || key(33)
+    const keyBuffer: Uint8Array = base58c.decode(base58key);
+    const keyView = createView(keyBuffer);
+    const version = keyView.getUint32(0, false);
+    const opt = {
+      versions,
+      depth: keyBuffer[4],
+      parentFingerprint: keyView.getUint32(5, false),
+      index: keyView.getUint32(9, false),
+      chainCode: keyBuffer.slice(13, 45)
+    };
+    const key = keyBuffer.slice(45);
+    const isPriv = key[0] === 0;
+    if (version !== versions[isPriv ? "private" : "public"]) {
+      throw new Error("Version mismatch");
+    }
+    if (isPriv) {
+      return new HDKey({ ...opt, privateKey: key.slice(1) });
+    } else {
+      return new HDKey({ ...opt, publicKey: key });
+    }
+  }
+
+  static fromJSON(json: { xpriv: string }): HDKey {
+    return HDKey.fromExtendedKey(json.xpriv);
+  }
+
+  constructor(opt: HDKeyOpt) {
+    if (!opt || typeof opt !== "object") {
+      throw new Error("HDKey.constructor must not be called directly");
+    }
+    this.versions = opt.versions || BITCOIN_VERSIONS;
+    this.depth = opt.depth || 0;
+    this.chainCode = opt.chainCode;
+    this.index = opt.index || 0;
+    this.parentFingerprint = opt.parentFingerprint || 0;
+    if (opt.publicKey && opt.privateKey)
+      throw new Error("HDKey: publicKey and privateKey at same time.");
+    if (opt.privateKey) {
+      if (!secp.utils.isValidPrivateKey(opt.privateKey)) {
+        throw new Error("Invalid private key");
+      }
+      this.privKey =
+        typeof opt.privateKey === "bigint"
+          ? opt.privateKey
+          : bytesToNumber(opt.privateKey);
+      this.privKeyBytes = numberToBytes(this.privKey);
+      this.pubKey = secp.getPublicKey(opt.privateKey, true);
+    } else if (opt.publicKey) {
+      this.pubKey = secp.Point.fromHex(opt.publicKey).toRawBytes(true); // force compressed point
+    } else {
+      throw new Error("HDKey: no public or private key provided");
+    }
+    this.pubHash = hash160(this.pubKey);
   }
   get fingerprint(): number {
     if (!this.pubHash) {
@@ -108,34 +152,9 @@ export class HDKey {
   get privateKey(): Uint8Array | null {
     return this.privKeyBytes || null;
   }
-  set privateKey(value: Uint8Array | bigint | null) {
-    if (value == null) {
-      this.wipePrivateData();
-      return;
-    }
-    if (!secp.utils.isValidPrivateKey(value)) {
-      throw new Error("Invalid private key");
-    }
-    this.privKey = typeof value === "bigint" ? value : bytesToNumber(value);
-    this.privKeyBytes = numberToBytes(this.privKey);
-    this.pubKey = secp.getPublicKey(value, true);
-    this.pubHash = hash160(this.pubKey);
-  }
   get publicKey(): Uint8Array | null {
     return this.pubKey || null;
   }
-  set publicKey(value: Uint8Array | null) {
-    let hex;
-    try {
-      hex = secp.Point.fromHex(value!);
-    } catch (error) {
-      throw new Error("Invalid public key");
-    }
-    this.pubKey = hex.toRawBytes(true); // force compressed point
-    this.pubHash = hash160(this.pubKey);
-    this.wipePrivateData();
-  }
-
   get privateExtendedKey(): string {
     const priv = this.privateKey;
     if (!priv) {
@@ -171,17 +190,18 @@ export class HDKey {
         throw new Error(`Invalid child index: ${c}`);
       }
       let idx = +m[1];
-      if (!Number.isSafeInteger(idx) || idx >= HDKey.HARDENED_OFFSET) {
+      if (!Number.isSafeInteger(idx) || idx >= HARDENED_OFFSET) {
         throw new Error("Invalid index");
       }
       // hardened key
       if (m[2] === "'") {
-        idx += HDKey.HARDENED_OFFSET;
+        idx += HARDENED_OFFSET;
       }
       child = child.deriveChild(idx);
     }
     return child;
   }
+
   public deriveChild(index: number): HDKey {
     if (!Number.isSafeInteger(index) || index < 0 || index >= 2 ** 33) {
       throw new Error(
@@ -193,7 +213,7 @@ export class HDKey {
     }
     let data = new Uint8Array(4);
     createView(data).setUint32(0, index, false);
-    if (index >= HDKey.HARDENED_OFFSET) {
+    if (index >= HARDENED_OFFSET) {
       // Hardened
       const priv = this.privateKey;
       if (!priv) {
@@ -211,7 +231,13 @@ export class HDKey {
     if (!secp.utils.isValidPrivateKey(childTweak)) {
       throw new Error("Tweak bigger than curve order");
     }
-    const child = new HDKey(this.versions);
+    const opt: HDKeyOpt = {
+      versions: this.versions,
+      chainCode,
+      depth: this.depth + 1,
+      parentFingerprint: this.fingerprint,
+      index
+    };
     try {
       // Private parent key -> private child key
       if (this.privateKey) {
@@ -221,28 +247,29 @@ export class HDKey {
             "The tweak was out of range or the resulted private key is invalid"
           );
         }
-        child.privateKey = added;
+        opt.privateKey = added;
       } else {
-        child.publicKey = secp.Point.fromHex(this.pubKey)
+        opt.publicKey = secp.Point.fromHex(this.pubKey)
           .add(secp.Point.fromPrivateKey(childTweak))
           .toRawBytes(true);
       }
+      return new HDKey(opt);
     } catch (err) {
       return this.deriveChild(index + 1);
     }
-    child.chainCode = chainCode;
-    child.depth = this.depth + 1;
-    child.parentFingerprint = this.fingerprint;
-    child.index = index;
-    return child;
   }
+
   public sign(hash: Uint8Array): Uint8Array {
     if (!this.privateKey) {
       throw new Error("No privateKey set!");
     }
     assertBytes(hash, 32);
-    return secp.signSync(hash, this.privKey!, { canonical: true, der: false });
+    return secp.signSync(hash, this.privKey!, {
+      canonical: true,
+      der: false
+    });
   }
+
   public verify(hash: Uint8Array, signature: Uint8Array): boolean {
     assertBytes(hash, 32);
     assertBytes(signature, 64);
@@ -257,10 +284,11 @@ export class HDKey {
     }
     return secp.verify(sig, hash, this.publicKey);
   }
+
   public wipePrivateData(): this {
     this.privKey = undefined;
-    if (this.privKeyBytes != null) {
-      this.privKeyBytes!.fill(0);
+    if (this.privKeyBytes) {
+      this.privKeyBytes.fill(0);
       this.privKeyBytes = undefined;
     }
     return this;

--- a/src/hdkey.ts
+++ b/src/hdkey.ts
@@ -133,7 +133,7 @@ export class HDKey {
     }
     this.pubKey = hex.toRawBytes(true); // force compressed point
     this.pubHash = hash160(this.pubKey);
-    this.privKey = undefined;
+    this.wipePrivateData();
   }
 
   get privateExtendedKey(): string {
@@ -258,12 +258,11 @@ export class HDKey {
     return secp.verify(sig, hash, this.publicKey);
   }
   public wipePrivateData(): this {
-    if (this.privKey) {
-      this.privKey = undefined;
+    this.privKey = undefined;
+    if (this.privKeyBytes != null) {
       this.privKeyBytes!.fill(0);
       this.privKeyBytes = undefined;
     }
-    this.privKey = undefined;
     return this;
   }
   public toJSON(): { xpriv: string; xpub: string } {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 // buf.toString('hex') -> toHex(buf)
-export { bytesToHex as toHex, createView } from "@noble/hashes/utils";
+import { assertBytes } from "@noble/hashes/utils";
+export { bytesToHex as toHex, assertBytes, createView } from "@noble/hashes/utils";
 // Buffer.from(hex, 'hex') -> hexToBytes(hex)
 export function hexToBytes(hex: string): Uint8Array {
   if (typeof hex !== "string") {
@@ -56,18 +57,6 @@ export function concatBytes(...arrays: Uint8Array[]): Uint8Array {
   return result;
 }
 // Internal utils
-export function assertBytes(bytes: Uint8Array, ...len: number[]) {
-  if (
-    bytes instanceof Uint8Array &&
-    (!len.length || len.includes(bytes.length))
-  ) {
-    return;
-  }
-  throw new TypeError(
-    `Expected ${len} bytes, not ${typeof bytes} with length=${bytes.length}`
-  );
-}
-
 export function assertBool(b: boolean) {
   if (typeof b !== "boolean") {
     throw new Error(`Expected boolean, not ${b}`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,10 @@
 // buf.toString('hex') -> toHex(buf)
 import { assertBytes } from "@noble/hashes/utils";
-export { bytesToHex as toHex, assertBytes, createView } from "@noble/hashes/utils";
+export {
+  assertBytes,
+  bytesToHex as toHex,
+  createView
+} from "@noble/hashes/utils";
 // Buffer.from(hex, 'hex') -> hexToBytes(hex)
 export function hexToBytes(hex: string): Uint8Array {
   if (typeof hex !== "string") {

--- a/test/test-vectors/hdkey.ts
+++ b/test/test-vectors/hdkey.ts
@@ -1,5 +1,5 @@
 import * as secp from "@noble/secp256k1";
-import { HDKey, HARDENED_OFFSET } from "../../src/hdkey";
+import { HARDENED_OFFSET, HDKey } from "../../src/hdkey";
 import { hexToBytes, toHex } from "../../src/utils";
 import { deepStrictEqual, throws } from "./assert";
 // https://github.com/cryptocoinjs/hdkey/blob/42637e381bdef0c8f785b14f5b66a80dad969514/test/fixtures/hdkey.json
@@ -160,7 +160,8 @@ describe("hdkey", () => {
 
   describe("- privateKey", () => {
     it("should throw an error if incorrect key size", () => {
-      const seed = "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542";
+      const seed =
+        "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542";
       const hdkey = HDKey.fromMasterSeed(hexToBytes(seed));
       // const hdkey = new HDKey.HDKey();
       throws(() => {
@@ -173,7 +174,8 @@ describe("hdkey", () => {
   describe("- publicKey", () => {
     it("should throw an error if incorrect key size", () => {
       throws(() => {
-        const seed = "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542";
+        const seed =
+          "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542";
         const hdkey = HDKey.fromMasterSeed(hexToBytes(seed));
         // @ts-ignore
         hdkey.publicKey = new Uint8Array([1, 2, 3, 4]);
@@ -183,19 +185,25 @@ describe("hdkey", () => {
     it("should not throw if key is 33 bytes (compressed)", () => {
       const pub = secp.getPublicKey(secp.utils.randomPrivateKey(), true);
       deepStrictEqual(pub.length, 33);
-      const seed = "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542";
+      const seed =
+        "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542";
       const hdkey = HDKey.fromMasterSeed(hexToBytes(seed));
-      // @ts-ignore
-      throws(() => { hdkey.publicKey = pub; });
+      throws(() => {
+        // @ts-ignore
+        hdkey.publicKey = pub;
+      });
     });
 
     it("should not throw if key is 65 bytes (not compressed)", () => {
       const pub = secp.getPublicKey(secp.utils.randomPrivateKey(), false);
       deepStrictEqual(pub.length, 65);
-      const seed = "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542";
+      const seed =
+        "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542";
       const hdkey = HDKey.fromMasterSeed(hexToBytes(seed));
-      // @ts-ignore
-      throws(() => { hdkey.publicKey = pub; });
+      throws(() => {
+        // @ts-ignore
+        hdkey.publicKey = pub;
+      });
     });
   });
 
@@ -347,7 +355,9 @@ describe("hdkey", () => {
       const masterKey = HDKey.fromMasterSeed(hexToBytes(seed));
 
       deepStrictEqual(!!masterKey.privateExtendedKey, true, "xpriv is truthy");
-      throws(() => { (masterKey as any).privateKey = undefined; });
+      throws(() => {
+        (masterKey as any).privateKey = undefined;
+      });
 
       // throws(() => masterKey.privateExtendedKey);
     });

--- a/test/test-vectors/hdkey.ts
+++ b/test/test-vectors/hdkey.ts
@@ -1,5 +1,5 @@
 import * as secp from "@noble/secp256k1";
-import { HDKey } from "../../src/hdkey";
+import { HDKey, HARDENED_OFFSET } from "../../src/hdkey";
 import { hexToBytes, toHex } from "../../src/utils";
 import { deepStrictEqual, throws } from "./assert";
 // https://github.com/cryptocoinjs/hdkey/blob/42637e381bdef0c8f785b14f5b66a80dad969514/test/fixtures/hdkey.json
@@ -160,8 +160,11 @@ describe("hdkey", () => {
 
   describe("- privateKey", () => {
     it("should throw an error if incorrect key size", () => {
-      const hdkey = new HDKey();
+      const seed = "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542";
+      const hdkey = HDKey.fromMasterSeed(hexToBytes(seed));
+      // const hdkey = new HDKey.HDKey();
       throws(() => {
+        // @ts-ignore
         hdkey.privateKey = new Uint8Array([1, 2, 3, 4]);
       });
     });
@@ -170,7 +173,9 @@ describe("hdkey", () => {
   describe("- publicKey", () => {
     it("should throw an error if incorrect key size", () => {
       throws(() => {
-        const hdkey = new HDKey();
+        const seed = "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542";
+        const hdkey = HDKey.fromMasterSeed(hexToBytes(seed));
+        // @ts-ignore
         hdkey.publicKey = new Uint8Array([1, 2, 3, 4]);
       });
     });
@@ -178,15 +183,19 @@ describe("hdkey", () => {
     it("should not throw if key is 33 bytes (compressed)", () => {
       const pub = secp.getPublicKey(secp.utils.randomPrivateKey(), true);
       deepStrictEqual(pub.length, 33);
-      const hdkey = new HDKey();
-      hdkey.publicKey = pub;
+      const seed = "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542";
+      const hdkey = HDKey.fromMasterSeed(hexToBytes(seed));
+      // @ts-ignore
+      throws(() => { hdkey.publicKey = pub; });
     });
 
     it("should not throw if key is 65 bytes (not compressed)", () => {
       const pub = secp.getPublicKey(secp.utils.randomPrivateKey(), false);
       deepStrictEqual(pub.length, 65);
-      const hdkey = new HDKey();
-      hdkey.publicKey = pub;
+      const seed = "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542";
+      const hdkey = HDKey.fromMasterSeed(hexToBytes(seed));
+      // @ts-ignore
+      throws(() => { hdkey.publicKey = pub; });
     });
   });
 
@@ -311,7 +320,7 @@ describe("hdkey", () => {
 
   describe("HARDENED_OFFSET", () => {
     it("should be set", () => {
-      deepStrictEqual(!!HDKey.HARDENED_OFFSET, true);
+      deepStrictEqual(!!HARDENED_OFFSET, true);
     });
   });
 
@@ -338,9 +347,9 @@ describe("hdkey", () => {
       const masterKey = HDKey.fromMasterSeed(hexToBytes(seed));
 
       deepStrictEqual(!!masterKey.privateExtendedKey, true, "xpriv is truthy");
-      (masterKey as any).privateKey = undefined;
+      throws(() => { (masterKey as any).privateKey = undefined; });
 
-      throws(() => masterKey.privateExtendedKey);
+      // throws(() => masterKey.privateExtendedKey);
     });
   });
 


### PR DESCRIPTION
I am extracting bip39 into a separate package that copy-pastes the code from js-e-c. https://github.com/paulmillr/micro-bip39

This is done for simplicity sake. Ideally, we would have js-e-c depend on it, but I could not set up dep deduplication correctly: micro-bip uses same deps as js-e-c and bundlers duplicate them.

Now, I still have one place that's different between micro-bip39 and js-ether

```diff
-import { assertBytes, assertNumber } from "@noble/hashes/utils";
+import { assertBytes, assertNumber, randomBytes } from "@noble/hashes/utils";
 import { utils as baseUtils } from "micro-base";
-import { getRandomBytesSync } from "../random";
 
 const isJapanese = (wordlist: string[]) =>
   wordlist[0] === "\u3042\u3044\u3053\u304f\u3057\u3093"; // Japanese wordlist
@@ -27,7 +26,7 @@ export function generateMnemonic(
   if (strength % 32 !== 0) {
     throw new TypeError("Invalid entropy");
   }
-  return entropyToMnemonic(getRandomBytesSync(strength / 8), wordlist);
+  return entropyToMnemonic(randomBytes(strength / 8), wordlist);
 }
```

Basically, as you can see, in micro-bip, I import `randomBytes` from noble-hashes and in `js-e-c` we import it from our own implementation, which duplicates noble-hashes' one.

Do you think we can merge the implementations and use noble-hashes-one? 