### PR TITLE
fix(ts): allow opt-in esModuleInterop (#1)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,27 +7,43 @@ on:
   pull_request:
     branches:
       - "*"
+env:
+  CI: true
+  COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+  PULL_NUMBER: ${{ github.event.pull_request.number }}
+  RUN_ID: ${{ github.run_id }}
+#  NODE_ENV: test
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
+  pipeline:
+    name: Node ${{ matrix.node-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: ['12.x', '14.x', '16.x']
+        os: ['ubuntu-latest']
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: npm install, build, and test
-      run: |
-        npm install
-        npm run test
-        npm run browser-tests
-        npm run lint
-      env:
-        CI: true
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install project dependencies
+        run: npm install
+        id: install
+
+      - name: Run project test
+        run: npm run test
+        id: test
+  
+      - name: Run Browser tests
+        run: npm run browser-tests
+        id: browser
+ 
+      - name: Check for lint issues
+        run: npm run lint
+        id: lint

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereum-cryptography",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "All the cryptographic primitives used in Ethereum",
   "contributors": [
     {
@@ -72,7 +72,8 @@
     "tslint": "^5.19.0",
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.0.1",
-    "typescript": "4.5.4",
+    "tslib": "2.4.0",
+    "typescript": "4.6.3",
     "webpack": "^4.39.3",
     "webpack-cli": "^3.3.8"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereum-cryptography",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "All the cryptographic primitives used in Ethereum",
   "contributors": [
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "target": "es2020",
     "module": "commonjs",
     "strict": true,
-    "esModuleInterop": true,
+    "esModuleInterop": false,
+    "importHelpers": true,
     "downlevelIteration": true,
     "rootDirs": [
       "./src",

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -3,7 +3,8 @@
     "target": "es2020",
     "module": "commonjs",
     "strict": true,
-    "esModuleInterop": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": false,
     "rootDir": "src",
     "outDir": ".",
     "declaration": true


### PR DESCRIPTION
## Opt in compiler options

**disable** the following compiler options:

`esModuleInterop`: `false`
`allowSyntheticDefaultImports`: `false`


The two flags `esModuleInterop` and `allowSyntheticDefaultImports` enable interoperation between ES Modules and CommonJS, AMD, and UMD modules for emit from TypeScript and type resolution by TypeScript respectively. 

Unfortunately these options are viral: **enabling them in a package requires all downstream consumers to enable them as well** .  The TLDR is due to the way CommonJS and ES Modules interoperate with bundlers (Webpack, Parcel, etc.). 

### Solution

 set both `allowSyntheticDefaultImports` and `esModuleInterop` to `false`. 

Consumers can now opt into these semantics, it also does not require them to do so. 
Consumers **can always safely use alternative import syntaxes (including falling back to require() and import()),** or can enable these flags and opt into this behavior themselves.

## additional stuff

included `tslib` as its referenced in a compiler option, `downlevelIteration`. Updated typescript to 4.6.3, also updated the CI workflow.
