### PR TITLE
Expose _createKeccak256. Upgrade deps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "*.d.ts"
   ],
   "dependencies": {
-    "@noble/hashes": "1.0.0",
-    "@noble/secp256k1": "1.5.5",
-    "@scure/bip32": "1.0.1",
-    "@scure/bip39": "1.0.0"
+    "@noble/hashes": "1.1.1",
+    "@noble/secp256k1": "1.6.0",
+    "@scure/bip32": "1.1.0",
+    "@scure/bip39": "1.1.0"
   },
   "browser": {
     "crypto": false

--- a/src/keccak.ts
+++ b/src/keccak.ts
@@ -1,7 +1,8 @@
-import * as sha3 from "@noble/hashes/sha3";
+import { keccak_224, keccak_256, keccak_384, keccak_512 } from "@noble/hashes/sha3";
 import { wrapHash } from "./utils";
 
-export const keccak224 = wrapHash(sha3.keccak_224);
-export const keccak256 = wrapHash(sha3.keccak_256);
-export const keccak384 = wrapHash(sha3.keccak_384);
-export const keccak512 = wrapHash(sha3.keccak_512);
+export const keccak224 = wrapHash(keccak_224);
+export const keccak256 = wrapHash(keccak_256);
+export const createKeccak256 = keccak_256.create;
+export const keccak384 = wrapHash(keccak_384);
+export const keccak512 = wrapHash(keccak_512);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,9 @@
 // buf.toString('hex') -> toHex(buf)
-import { assertBytes } from "@noble/hashes/utils";
+import assert from "@noble/hashes/_assert";
+const assertBool = assert.bool;
+const assertBytes = assert.bytes;
+export { assertBool, assertBytes };
 export {
-  assertBool,
-  assertBytes,
   bytesToHex,
   bytesToHex as toHex,
   concatBytes,
@@ -35,7 +36,7 @@ export function equalsBytes(a: Uint8Array, b: Uint8Array): boolean {
 // Internal utils
 export function wrapHash(hash: (msg: Uint8Array) => Uint8Array) {
   return (msg: Uint8Array) => {
-    assertBytes(msg);
+    assert.bytes(msg);
     return hash(msg);
   };
 }


### PR DESCRIPTION
`_createKeccak256` because it's temporary until we'll think of a new name. I don't want folks to depend on stable api with bad name.