### PR TITLE
Switch from noble-secp256k1 to noble-curves

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: [14, 16, 18]
+        node: [16, 18, 19]
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -167,31 +167,29 @@ console.log(getRandomBytesSync(32));
 ## secp256k1 curve
 
 ```ts
-function getPublicKey(privateKey: Uint8Array, isCompressed?: false): Uint8Array;
-function getSharedSecret(privateKeyA: Uint8Array, publicKeyB: Uint8Array): Uint8Array;
-function sign(msgHash: Uint8Array, privateKey: Uint8Array, opts?: Options): Promise<Uint8Array>;
-function signSync(msgHash: Uint8Array, privateKey: Uint8Array, opts?: Options): Uint8Array;
+function getPublicKey(privateKey: Uint8Array, isCompressed = true): Uint8Array;
+function sign(msgHash: Uint8Array, privateKey: Uint8Array): { r: bigint; s: bigint; recovery: number };
 function verify(signature: Uint8Array, msgHash: Uint8Array, publicKey: Uint8Array): boolean
-function recoverPublicKey(msgHash: Uint8Array, signature: Uint8Array, recovery: number): Uint8Array | undefined;
+function getSharedSecret(privateKeyA: Uint8Array, publicKeyB: Uint8Array): Uint8Array;
 function utils.randomPrivateKey(): Uint8Array;
 ```
 
 The `secp256k1` submodule provides a library for elliptic curve operations on
-the curve secp256k1. For detailed documentation, follow [README of `noble-secp256k1`](https://github.com/paulmillr/noble-secp256k1), which the module uses as a backend.
+the curve secp256k1. For detailed documentation, follow [README of `noble-curves`](https://github.com/paulmillr/noble-curves), which the module uses as a backend.
 
 secp256k1 private keys need to be cryptographically secure random numbers with
 certain caracteristics. If this is not the case, the security of secp256k1 is
 compromised. We strongly recommend using `utils.randomPrivateKey()` to generate them.
 
 ```js
-const secp = require("ethereum-cryptography/secp256k1");
+const {secp256k1} = require("ethereum-cryptography/secp256k1");
 (async () => {
   // You pass either a hex string, or Uint8Array
   const privateKey = "6b911fd37cdf5c81d4c0adb1ab7fa822ed253ab0ad9aa18d77257c88b29b718e";
   const messageHash = "a33321f98e4ff1c283c76998f14f57447545d339b3db534c6d886decb4209f28";
-  const publicKey = secp.getPublicKey(privateKey);
-  const signature = await secp.sign(messageHash, privateKey);
-  const isSigned = secp.verify(signature, messageHash, publicKey);
+  const publicKey = secp256k1.getPublicKey(privateKey);
+  const signature = secp256k1.sign(messageHash, privateKey);
+  const isSigned = secp256k1.verify(signature, messageHash, publicKey);
 })();
 ```
 
@@ -448,9 +446,12 @@ you found another primitive that is missing.
 
 ## Upgrading
 
-Version 1.0 changes from 0.1:
+Upgrading from 1.0 to 2.0: `secp256k1` module was changed massively:
+before, it was using [noble-secp256k1 1.7](https://github.com/paulmillr/noble-secp256k1);
+now it uses safer [noble-curves](https://github.com/paulmillr/noble-curves). Please refer
+to [upgrading section from curves README](https://github.com/paulmillr/noble-curves#upgrading).
 
-**Same functionality**, all old APIs remain the same except for the breaking changes:
+Upgrading from 0.1 to 1.0: **Same functionality**, all old APIs remain the same except for the breaking changes:
 
 1. We return `Uint8Array` from all methods that worked with `Buffer` before.
 `Buffer` has never been supported in browsers, while `Uint8Array`s are supported natively in both

--- a/README.md
+++ b/README.md
@@ -446,10 +446,13 @@ you found another primitive that is missing.
 
 ## Upgrading
 
-Upgrading from 1.0 to 2.0: `secp256k1` module was changed massively:
-before, it was using [noble-secp256k1 1.7](https://github.com/paulmillr/noble-secp256k1);
-now it uses safer [noble-curves](https://github.com/paulmillr/noble-curves). Please refer
-to [upgrading section from curves README](https://github.com/paulmillr/noble-curves#upgrading).
+Upgrading from 1.0 to 2.0:
+
+1. `secp256k1` module was changed massively:
+  before, it was using [noble-secp256k1 1.7](https://github.com/paulmillr/noble-secp256k1);
+  now it uses safer [noble-curves](https://github.com/paulmillr/noble-curves). Please refer
+  to [upgrading section from curves README](https://github.com/paulmillr/noble-curves#upgrading).
+2. node.js 14 and older support was dropped. Upgrade to node.js 16 or later. 
 
 Upgrading from 0.1 to 1.0: **Same functionality**, all old APIs remain the same except for the breaking changes:
 

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "*.d.ts"
   ],
   "dependencies": {
-    "@noble/hashes": "1.2.0",
-    "@noble/secp256k1": "1.7.1",
-    "@scure/bip32": "1.1.5",
-    "@scure/bip39": "1.1.1"
+    "@noble/curves": "0.9.1",
+    "@noble/hashes": "1.3.0",
+    "@scure/bip32": "1.2.0",
+    "@scure/bip39": "1.2.0"
   },
   "browser": {
     "crypto": false
@@ -53,13 +53,13 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "22.0.1",
     "@rollup/plugin-node-resolve": "13.3.0",
-    "@types/estree": "0.0.47",
+    "@types/estree": "1.0.0",
     "@types/mocha": "9.1.1",
-    "@types/node": "18.0.4",
+    "@types/node": "18.15.11",
     "@typescript-eslint/eslint-plugin": "5.30.6",
     "@typescript-eslint/parser": "5.30.6",
     "browserify": "17.0.0",
-    "eslint": "8.19.0",
+    "eslint": "8.38.0",
     "eslint-plugin-prettier": "4.2.1",
     "karma": "6.4.0",
     "karma-chrome-launcher": "3.1.1",
@@ -72,8 +72,8 @@
     "rimraf": "~3.0.2",
     "rollup": "2.76.0",
     "ts-node": "10.9.1",
-    "typescript": "4.7.3",
-    "webpack": "5.73.0",
+    "typescript": "5.0.2",
+    "webpack": "5.76.0",
     "webpack-cli": "4.10"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "*.d.ts"
   ],
   "dependencies": {
-    "@noble/curves": "0.9.1",
+    "@noble/curves": "1.0.0",
     "@noble/hashes": "1.3.0",
-    "@scure/bip32": "1.2.0",
+    "@scure/bip32": "1.3.0",
     "@scure/bip39": "1.2.0"
   },
   "browser": {

--- a/src/aes.ts
+++ b/src/aes.ts
@@ -1,5 +1,7 @@
-import { crypto } from "@noble/hashes/crypto";
+import { crypto as cr } from "@noble/hashes/crypto";
 import { concatBytes, equalsBytes } from "./utils";
+
+const crypto: any = { web: cr };
 
 function validateOpt(key: Uint8Array, iv: Uint8Array, mode: string) {
   if (!mode.startsWith("aes-")) {

--- a/src/secp256k1.ts
+++ b/src/secp256k1.ts
@@ -1,23 +1,2 @@
-import { hmac } from "@noble/hashes/hmac";
-import { sha256 } from "@noble/hashes/sha256";
-import { utils as _utils } from "@noble/secp256k1";
-export {
-  getPublicKey,
-  sign,
-  signSync,
-  verify,
-  recoverPublicKey,
-  getSharedSecret,
-  utils,
-  CURVE,
-  Point,
-  Signature,
-  schnorr
-} from "@noble/secp256k1";
-
-// Enable sync API for noble-secp256k1
-_utils.hmacSha256Sync = (key: Uint8Array, ...messages: Uint8Array[]) => {
-  const h = hmac.create(sha256, key);
-  messages.forEach(msg => h.update(msg));
-  return h.digest();
-};
+// import { secp256k1 } from "@noble/curves/secp256k1";
+export { secp256k1 } from "@noble/curves/secp256k1";

--- a/src/secp256k1.ts
+++ b/src/secp256k1.ts
@@ -1,2 +1,1 @@
-// import { secp256k1 } from "@noble/curves/secp256k1";
 export { secp256k1 } from "@noble/curves/secp256k1";

--- a/test/test-vectors/hdkey.ts
+++ b/test/test-vectors/hdkey.ts
@@ -1,4 +1,4 @@
-import * as secp from "@noble/secp256k1";
+import { secp256k1 as secp } from "@noble/curves/secp256k1";
 import { HARDENED_OFFSET, HDKey } from "../../src/hdkey";
 import { hexToBytes, toHex } from "../../src/utils";
 import { deepStrictEqual, throws } from "./assert";

--- a/test/test-vectors/secp256k1.ts
+++ b/test/test-vectors/secp256k1.ts
@@ -1,4 +1,4 @@
-import * as secp from "../../src/secp256k1";
+import { secp256k1 } from "../../src/secp256k1";
 import { deepStrictEqual } from "./assert";
 
 describe("secp256k1", () => {
@@ -9,8 +9,8 @@ describe("secp256k1", () => {
     const y = 17482644437196207387910659778872952193236850502325156318830589868678978890912n;
     const r = 432420386565659656852420866390673177323n;
     const s = 115792089237316195423570985008687907852837564279074904382605163141518161494334n;
-    const pub = new secp.Point(x, y);
-    const sig = new secp.Signature(r, s);
-    deepStrictEqual(secp.verify(sig, msg, pub, { strict: false }), true);
+    const pub = new secp256k1.ProjectivePoint(x, y, 1n);
+    const sig = new secp256k1.Signature(r, s);
+    deepStrictEqual(secp256k1.verify(sig, msg, pub.toRawBytes(), { lowS: false }), true);
   });
 });


### PR DESCRIPTION
Since we re-export all secp256k1 functions, upgrading to noble-curves changes the API in backwards-incompatible way. Meaning we should release 2.0. Perhaps with ESM?

Node.js 14 was dropped:

- noble-hashes 1.3 switched from `require(crypto)` to webcrypto
- its support ends on April 28