### PR TITLE
chore: fix typos

### DIFF
--- a/test/test-vectors/bip39.ts
+++ b/test/test-vectors/bip39.ts
@@ -51,7 +51,7 @@ describe("BIP39", () => {
     });
   });
 
-  describe("Entropy-mnemonic convertions", () => {
+  describe("Entropy-mnemonic conversions", () => {
     describe("Should convert from mnemonic to entropy and back", () => {
       it("should work with the English wodlist", () => {
         const mnemonic = generateMnemonic(englishWordlist, 128);


### PR DESCRIPTION
fix a typo: `convertions`->`convertions`