### PR TITLE
chore: set packageManager=npm@9.9.3 in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "1.4.2",
+        "@noble/curves": "1.5.0",
         "@noble/hashes": "1.4.0",
         "@scure/bip32": "1.4.0",
         "@scure/bip39": "1.3.0"
@@ -524,9 +524,9 @@
       ]
     },
     "node_modules/@noble/curves": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
-      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.5.0.tgz",
+      "integrity": "sha512-J5EKamIHnKPyClwVrzmaf5wSdQXgdHcPZIZLu3bwnbeCx8/7NPK5q2ZBWF+5FvYGByjiQQsJYX6jfgB2wDPn3A==",
       "dependencies": {
         "@noble/hashes": "1.4.0"
       },
@@ -2190,6 +2190,17 @@
         "@noble/curves": "~1.4.0",
         "@noble/hashes": "~1.4.0",
         "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
+      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+      "dependencies": {
+        "@noble/hashes": "1.4.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"

--- a/package.json
+++ b/package.json
@@ -329,6 +329,7 @@
     "webpack": "5.94.0",
     "webpack-cli": "4.10.0"
   },
+  "packageManager": "npm@9.9.3",
   "keywords": [
     "ethereum",
     "cryptography",


### PR DESCRIPTION
Set [`packageManager`](https://nodejs.org/docs/latest-v18.x/api/packages.html#packagemanager) field in package manifest.

Ensures [corepack](https://github.com/nodejs/corepack) users use consistent version of npm.

v9 is chosen due to its wide compatibility (nodejs v14, v16, >=v18).

---
- Blocked by #121