### PR TITLE
[v3]: Indicate supported Node.js versions; test on Node.js v16

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,7 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         node:
+          - 16.0.0
           - 16
+          - 18.0.0
           - 18
           - 20
           # TODO: Unpin to `22` once parcel incomaptibility with 22.7+ is resolved

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,6 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         node:
+          - 16
           - 18
           - 20
           # TODO: Unpin to `22` once parcel incomaptibility with 22.7+ is resolved

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "repository": "https://github.com/ethereum/js-ethereum-cryptography",
   "license": "MIT",
   "main": "./index.js",
+  "engines": {
+    "node": "^16.20 || ^18 || ^20 || >=22"
+  },
   "files": [
     "bip39/*.js",
     "bip39/*.d.ts",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "./index.js",
   "engines": {
-    "node": "^16.20 || ^18 || ^20 || >=22"
+    "node": "16.x || >= 18.0.0"
   },
   "files": [
     "bip39/*.js",


### PR DESCRIPTION
- Targeting #125

---

- Indicate supported Node.js versions via `engines.node` in manifest
- ci: Test on node.js v16