### PR TITLE
[v3] npm version 9

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -30,6 +30,7 @@ jobs:
         node-version: ${{ matrix.node }}
         registry-url: 'https://registry.npmjs.org'
         cache: 'npm'
+    - run: npm install -g npm@9.x
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "main": "./index.js",
   "engines": {
-    "node": "^14.21.3 || >=16"
+    "node": "^14.21.3 || >=16",
+    "npm": ">=9"
   },
   "files": [
     "bip39/*.js",


### PR DESCRIPTION
- targeting: #125

--- 

- chore(ci) pin npm v9.x
- chore: indicate all supported npm versions via `engines.npm` in `package.json`
  - somewhat redundant with `packageManager` field but serves different purpose and recognized by npm itself
