### PR TITLE
Update README.md - Fix bad example

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ const isValidEth = bls.verify(signature, message, publicKey, htfEthereum);
 
 // Aggregation
 const aggregatedKey = bls.aggregatePublicKeys([
-  bls.utils.randomPrivateKey(),
-  bls.utils.randomPrivateKey(),
+  bls.getPublicKey(bls.utils.randomPrivateKey()),
+  bls.getPublicKey(bls.utils.randomPrivateKey()),
 ]);
 // const aggregatedSig = bls.aggregateSignatures(sigs)
 


### PR DESCRIPTION
- Fix broken readme for BLS

The method is expecting pubic keys `aggregatePublicKeys` and it is getting private keys.