### PR TITLE
Prepare 3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ethereum-cryptography",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ethereum-cryptography",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereum-cryptography",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "All the cryptographic primitives used in Ethereum",
   "repository": "https://github.com/ethereum/js-ethereum-cryptography",
   "license": "MIT",


### PR DESCRIPTION
Needs review

## Changelog

- utils: use built-in Uint8Array toHex / fromHex [when available](https://caniuse.com/mdn-javascript_builtins_uint8array_fromhex). Gives 13x speed-up on 256b arrays, 20x speed-up on 32kb arrays
- utils.randomBytes: ensure same return type Uint8Array in old nodejs
- ciphers: update from v1.2.1 to v1.3.0. [diff](https://github.com/paulmillr/noble-ciphers/compare/1.2.1..1.3.0)
- hashes: update from v1.7.1 to v1.8.0. [diff](https://github.com/paulmillr/noble-hashes/compare/1.7.1..1.8.0)
    - Submodule renames, refactoring
- curves: update from v1.8.1 to v1.9.0. [diff](https://github.com/paulmillr/noble-curves/compare/1.8.1..1.9.0)
    - weierstrass: prohibit y=0 when initializing
    - modular: improve sqrt logic
- bip32: update from v1.6.2 to v1.7.0. [diff](https://github.com/paulmillr/scure-bip32/compare/1.6.2..1.7.0)
- bip39: update from v1.5.4 to v1.6.0. [diff](https://github.com/paulmillr/scure-bip39/compare/1.5.4..1.6.0)
- base: update from v1.2.4 to v1.2.5 [diff](https://github.com/paulmillr/scure-base/compare/1.2.4..1.2.5)
